### PR TITLE
fix: allow null/undefined as a match result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,15 @@ interface IPattern {
 
 const match = (value: string, pattern: IPattern) => {
   const hasKey = (key: string) => String(value) === key
-  const matchingCase = Object.keys(pattern).find(hasKey) || '_'
-  const result = pattern[matchingCase]
+  const matchingCase = Object.keys(pattern).find(hasKey)
+  const defaultCase = '_'
+  const hasDefault = pattern.hasOwnProperty(defaultCase)
 
-  if (result === null || (typeof result === 'undefined')) {
-    throw new Error('Match error')
+  if (!matchingCase && !hasDefault) {
+    throw new Error(`Match error for value: ${value}`)
   }
 
-  return result
+  return pattern[matchingCase || defaultCase]
 }
 
 const lazyMatch = (pattern: IPattern) => (value: string) => match(value, pattern)


### PR DESCRIPTION
### BEFORE

It throws a match error when there is null/undefined on any branch

### AFTER

- Allow any values as a result
- Only check missing case in the pattern